### PR TITLE
Fixed bug when loading page hovering a li

### DIFF
--- a/js/megamenu.js
+++ b/js/megamenu.js
@@ -25,11 +25,19 @@ $(document).ready(function () {
     });
     //If width is more than 943px dropdowns are displayed on hover
 
-    $(".menu > ul > li").click(function () {
-        if ($(window).width() <= 943) {
-            $(this).children("ul").fadeToggle(150);
+    $(".menu > ul > li").hover(
+        function (e) {
+            if ($(window).width() > 943) {
+                $(this).children("ul").stop(true, false).fadeIn(150);
+                e.preventDefault();
+            }
+        }, function (e) {
+            if ($(window).width() > 943) {
+                $(this).children("ul").stop(true, false).fadeOut(150);
+                e.preventDefault();
+            }
         }
-    });
+    );
     //If width is less or equal to 943px dropdowns are displayed on click (thanks Aman Jain from stackoverflow)
 
     $(".menu-mobile").click(function (e) {


### PR DESCRIPTION
I've made this change to fix this issue, basically if you load the page, and your mouse in hovering a first level li before the document is ready, that li will work backwards; so hover to hide, mouseleave to show