### PR TITLE
Improvements

### DIFF
--- a/js/megamenu.js
+++ b/js/megamenu.js
@@ -32,6 +32,13 @@ $(document).ready(function () {
     );
     //If width is more than 943px dropdowns are displayed on hover
 
+
+    //the following hides the menu when a click is registered outside
+    $(document).on('click', function(e){
+        if($(e.target).parents('.menu').length === 0)
+            $(".menu > ul").removeClass('show-on-mobile');
+    });
+
     $(".menu > ul > li").click(function() {
         //no more overlapping menus
         //hides other children menus when a list item with children menus is clicked

--- a/js/megamenu.js
+++ b/js/megamenu.js
@@ -33,8 +33,14 @@ $(document).ready(function () {
     //If width is more than 943px dropdowns are displayed on hover
 
     $(".menu > ul > li").click(function() {
+        //no more overlapping menus
+        //hides other children menus when a list item with children menus is clicked
+        var thisMenu = $(this).children("ul");
+        var prevState = thisMenu.css('display');
+        $(".menu > ul > li > ul").fadeOut();
         if ($(window).width() < 943) {
-          $(this).children("ul").fadeToggle(150);
+            if(prevState !== 'block')
+                thisMenu.fadeIn(150);
         }
     });
     //If width is less or equal to 943px dropdowns are displayed on click (thanks Aman Jain from stackoverflow)


### PR DESCRIPTION
Two little improvements that help usability:

- Menu's don't overlap on mobile: if I open one menu within a parent menu and I don't close it and open up another menu it overlaps, one of my commits fixed this issue from happening by hiding every other child menu except for the one being expanded

- The mobile menu hides when anywhere else on the DOM but the mobile menu is clicked